### PR TITLE
Lintification

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,5 @@
+/*
+Package pmxadapter provides the server and structures to respond to Panamax
+Remote Agent Requests.
+*/
+package pmxadapter

--- a/encoding.go
+++ b/encoding.go
@@ -1,4 +1,3 @@
-//Package api provides the server and structures to respond to Panamax Remote Agent Requests.
 package pmxadapter
 
 import (

--- a/handlers.go
+++ b/handlers.go
@@ -94,7 +94,7 @@ func deleteService(adapter PanamaxAdapter, params martini.Params) (int, string) 
 // version and type of adapter.
 func getMetadata(e encoder, adapter PanamaxAdapter) (int, string) {
 
-	data := &Metadata{Version: VERSION, Type: "marathon"}
+	data := &Metadata{Version: Version, Type: "marathon"}
 
 	return http.StatusOK, e.Encode(data)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -94,7 +94,7 @@ func deleteService(adapter PanamaxAdapter, params martini.Params) (int, string) 
 // version and type of adapter.
 func getMetadata(e encoder, adapter PanamaxAdapter) (int, string) {
 
-	data := &Metadata{Version: Version, Type: "marathon"}
+	data := adapter.GetMetadata()
 
-	return http.StatusOK, e.Encode(data)
+	return http.StatusOK, e.Encode(&data)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -34,6 +34,9 @@ func (e MockAdapter) UpdateService(*Service) *Error {
 func (e MockAdapter) DestroyService(string) *Error {
 	return e.returnError
 }
+func (e MockAdapter) GetMetadata() Metadata {
+	return Metadata{Type: "mock", Version: "0.1"}
+}
 
 func newMockAdapter(code int, message string) *MockAdapter {
 	adapter := new(MockAdapter)

--- a/server.go
+++ b/server.go
@@ -10,9 +10,10 @@ import (
 	"github.com/codegangsta/martini"
 )
 
+// Version numbers for the API and adapter release.
 const (
-	API_VERSION = "v1"
-	VERSION     = "0.1.0"
+	APIVersion = "v1"
+	Version    = "0.1.0"
 )
 
 type martiniServer struct {
@@ -34,7 +35,7 @@ func NewServer(adapterInst PanamaxAdapter) *martiniServer {
 	})
 	// Setup routes
 	router := martini.NewRouter()
-	router.Group(fmt.Sprintf("/%s", API_VERSION), func(r martini.Router) {
+	router.Group(fmt.Sprintf("/%s", APIVersion), func(r martini.Router) {
 		r.Get(`/services`, getServices)
 		r.Get(`/services/:id`, getService)
 		r.Post(`/services`, createServices)

--- a/server.go
+++ b/server.go
@@ -16,6 +16,12 @@ const (
 	Version    = "0.1.0"
 )
 
+// The AdapterServer serves your PanamaxAdapter-implementing adapter via the
+// standard API that Panamax speaks.
+type AdapterServer interface {
+	Start()
+}
+
 type martiniServer struct {
 	svr *martini.Martini
 }
@@ -23,7 +29,7 @@ type martiniServer struct {
 // NewServer creates an instance of a martini server. The
 // adapterInst parameter is the adapter type the server will
 // use when dispatching requests.
-func NewServer(adapterInst PanamaxAdapter) *martiniServer {
+func NewServer(adapterInst PanamaxAdapter) AdapterServer {
 	s := martini.New()
 
 	// Setup middleware

--- a/server.go
+++ b/server.go
@@ -10,11 +10,8 @@ import (
 	"github.com/codegangsta/martini"
 )
 
-// Version numbers for the API and adapter release.
-const (
-	APIVersion = "v1"
-	Version    = "0.1.0"
-)
+// The Version of the API exposed by AdapterServer.
+const APIVersion = "v1"
 
 // The AdapterServer serves your PanamaxAdapter-implementing adapter via the
 // standard API that Panamax speaks.

--- a/server_test.go
+++ b/server_test.go
@@ -13,7 +13,7 @@ import (
 var testServer *httptest.Server
 
 func init() {
-	martini := NewServer(new(NoOPAdapter))
+	martini := NewServer(new(NoOPAdapter)).(*martiniServer)
 	testServer = httptest.NewServer(martini.svr)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,8 +1,10 @@
 package pmxadapter
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,6 +37,9 @@ func (NoOPAdapter) UpdateService(*Service) *Error {
 }
 func (NoOPAdapter) DestroyService(string) *Error {
 	return nil
+}
+func (NoOPAdapter) GetMetadata() Metadata {
+	return Metadata{Type: "NOOP", Version: "0.1"}
 }
 
 func TestGetServicesRoute(t *testing.T) {
@@ -74,8 +79,14 @@ func TestDeleteServiceRoute(t *testing.T) {
 
 func TestGetMetadataRoute(t *testing.T) {
 	res, _ := http.Get(fmt.Sprintf("%s/v1/metadata", testServer.URL))
+	m := Metadata{}
+	j, _ := ioutil.ReadAll(res.Body)
+	err := json.Unmarshal(j, &m)
+	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "NOOP", m.Type)
+	assert.Equal(t, "0.1", m.Version)
 }
 
 func TestNoRoute(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -19,7 +19,7 @@ type PanamaxAdapter interface {
 // actualState is used to provide status back to the remote
 // agent.
 type Service struct {
-	Id          string         `json:"id"`
+	ID          string         `json:"id"`
 	Name        string         `json:"name,omitempty"`
 	Source      string         `json:"source,omitempty"`
 	Command     string         `json:"command,omitempty"`
@@ -67,6 +67,7 @@ type Volume struct {
 	ContainerPath string `json:"containerPath"`
 }
 
+// VolumesFrom allows volumes to be mounted from another container.
 type VolumesFrom struct {
 	Name string `json:"name"`
 }

--- a/types.go
+++ b/types.go
@@ -12,6 +12,7 @@ type PanamaxAdapter interface {
 	CreateServices([]*Service) ([]*Service, *Error)
 	UpdateService(*Service) *Error
 	DestroyService(string) *Error
+	GetMetadata() Metadata
 }
 
 // A Service describes the information needed to deploy and

--- a/types_test.go
+++ b/types_test.go
@@ -87,7 +87,7 @@ func TestMarshalService(t *testing.T) {
 	environment := Environment{Variable: "start", Value: "end"}
 	volume := Volume{HostPath: "foo", ContainerPath: "bar"}
 	volumesFrom := VolumesFrom{Name: "myvolume"}
-	service := Service{Id: "myService", Name: "myServiceName", Source: "centurylink/service", Command: "/run.sh",
+	service := Service{ID: "myService", Name: "myServiceName", Source: "centurylink/service", Command: "/run.sh",
 		Links:       []*Link{&link},
 		Ports:       []*Port{&port},
 		Environment: []*Environment{&environment},
@@ -106,7 +106,7 @@ func TestUnmarshalService(t *testing.T) {
 	str := `{"id":"myService","name":"myServiceName","source":"centurylink/service","command":"/run.sh","links":[{"name":"db","alias":"db_1"}],"ports":[{"hostPort":8080,"containerPort":8080}],"expose":[8080,9000],"environment":[{"variable":"start","value":"end"}],"volumes":[{"hostPath":"foo","containerPath":"bar"}],"volumes_from":[{"name":"myvolume"}],"deployment":{"count":1}}`
 	json.Unmarshal([]byte(str), &service)
 
-	assert.Equal(t, "myService", service.Id)
+	assert.Equal(t, "myService", service.ID)
 	assert.Equal(t, "myServiceName", service.Name)
 	assert.Equal(t, 8080, service.Ports[0].ContainerPort)
 	assert.Equal(t, "bar", service.Volumes[0].ContainerPath)


### PR DESCRIPTION
I was looking at this and noticed some variable names that didn't follow [Effective Go's](https://golang.org/doc/effective_go.html#mixed-caps) suggested naming convention. I ran `golint` (which is pretty much a software enforcer of many rules from Effective Go) against the codebase and changed some stuff to get it to quiet down. All pretty minor, with the possible exception of the `martiniServer` -> AdapterServer` thing, which isn't much. I will update your sample adapter to this codebase if you approve, @argvader.
