### PR TITLE
Allow PanamaxAdapter to provide its metadata.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -94,7 +94,7 @@ func deleteService(adapter PanamaxAdapter, params martini.Params) (int, string) 
 // version and type of adapter.
 func getMetadata(e encoder, adapter PanamaxAdapter) (int, string) {
 
-	data := &Metadata{Version: Version, Type: "marathon"}
+	data := adapter.GetMetadata()
 
-	return http.StatusOK, e.Encode(data)
+	return http.StatusOK, e.Encode(&data)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -34,6 +34,9 @@ func (e MockAdapter) UpdateService(*Service) *Error {
 func (e MockAdapter) DestroyService(string) *Error {
 	return e.returnError
 }
+func (e MockAdapter) GetMetadata() Metadata {
+	return Metadata{Type: "mock", Version: "0.1"}
+}
 
 func newMockAdapter(code int, message string) *MockAdapter {
 	adapter := new(MockAdapter)

--- a/server.go
+++ b/server.go
@@ -10,11 +10,8 @@ import (
 	"github.com/codegangsta/martini"
 )
 
-// Version numbers for the API and adapter release.
-const (
-	APIVersion = "v1"
-	Version    = "0.1.0"
-)
+// The Version of the API exposed by AdapterServer.
+const APIVersion = "v1"
 
 // The AdapterServer serves your PanamaxAdapter-implementing adapter via the
 // standard API that Panamax speaks.

--- a/server_test.go
+++ b/server_test.go
@@ -1,8 +1,10 @@
 package pmxadapter
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,6 +37,9 @@ func (NoOPAdapter) UpdateService(*Service) *Error {
 }
 func (NoOPAdapter) DestroyService(string) *Error {
 	return nil
+}
+func (NoOPAdapter) GetMetadata() Metadata {
+	return Metadata{Type: "NOOP", Version: "0.1"}
 }
 
 func TestGetServicesRoute(t *testing.T) {
@@ -74,8 +79,14 @@ func TestDeleteServiceRoute(t *testing.T) {
 
 func TestGetMetadataRoute(t *testing.T) {
 	res, _ := http.Get(fmt.Sprintf("%s/v1/metadata", testServer.URL))
+	m := Metadata{}
+	j, _ := ioutil.ReadAll(res.Body)
+	err := json.Unmarshal(j, &m)
+	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "NOOP", m.Type)
+	assert.Equal(t, "0.1", m.Version)
 }
 
 func TestNoRoute(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -12,6 +12,7 @@ type PanamaxAdapter interface {
 	CreateServices([]*Service) ([]*Service, *Error)
 	UpdateService(*Service) *Error
 	DestroyService(string) *Error
+	GetMetadata() Metadata
 }
 
 // A Service describes the information needed to deploy and


### PR DESCRIPTION
I think this got missed while you were extracting from Marathon. The implementer of the interface is the only one that can really know the adapter version and type. Again, I'll update the sample app if this looks OK. You will have to update your blog post to reflect the new required method.

This PR could stand on its own, apart from #1, but there would be some merge conflicts. So this merges into #1, but it could go separate if it had to.
